### PR TITLE
Add https prefix to user input url

### DIFF
--- a/Managed View/ViewController.swift
+++ b/Managed View/ViewController.swift
@@ -282,8 +282,11 @@ class ViewController: UIViewController, UITextFieldDelegate, WKUIDelegate, WKNav
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder() // hide the keyboard
         
-        let userURL = URL(string: browserURL.text!)
-        config.newURL = userURL
+        // Add https prefix while user often does't provide url scheme.
+        var urlComponents = URLComponents()
+        urlComponents.scheme = "https"
+        urlComponents.host = browserURL.text
+        config.newURL = urlComponents.url
         
         loadWebView()
         


### PR DESCRIPTION
User often doesn't type `http` or `https` when editing url and it causes a WKView doesn't load the request properly. It would be good if we fix it whether user provides url scheme or not.