### PR TITLE
 Fix White Bar at Bottom of Screen with Refactored WKWebView Configuration

### DIFF
--- a/Managed View/ViewController.swift
+++ b/Managed View/ViewController.swift
@@ -183,7 +183,7 @@ class ViewController: UIViewController, UITextFieldDelegate, WKUIDelegate, WKNav
                 self.newWebView()
             }
         }
- 
+
         DispatchQueue.main.async {
             self.loadWebView()
         }
@@ -196,34 +196,33 @@ class ViewController: UIViewController, UITextFieldDelegate, WKUIDelegate, WKNav
         NSLog(String(describing: config))
     }
     
-    // initiate new Web View - persistent
-    func newWebView() {
+    private func configureWebView(isPrivate: Bool = false) -> WKWebView {
         let webConfiguration = WKWebViewConfiguration()
-        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        if isPrivate {
+            webConfiguration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        }
+        let webView = WKWebView(frame: .zero, configuration: webConfiguration)
         webView.uiDelegate = self
         webView.navigationDelegate = self
         browserURL.delegate = self
-        
+        if #available(iOS 11.0, *) {
+            webView.scrollView.contentInsetAdjustmentBehavior = .never
+        }
+        return webView
+    }
+
+    func newWebView() {
+        webView = configureWebView()
         view = webView
         NSLog("Initiate webview - persistant")
-
     }
-    
-    // initiate new Web View - non-persistent
+
     func newWebViewPrivate() {
-        let webConfiguration = WKWebViewConfiguration()
-        // Private Mode v2.1
-        webConfiguration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-        webView = WKWebView(frame: .zero, configuration: webConfiguration)
-        webView.uiDelegate = self
-        webView.navigationDelegate = self
-        browserURL.delegate = self
-        
+        webView = configureWebView(isPrivate: true)
         view = webView
         NSLog("Initiate webview - non-persistant")
-
     }
-    
+
     // load new URL request & check scheme (v2.3.1)
     func loadWebView() {
         var urlComponents = URLComponents()


### PR DESCRIPTION
Hello, my name is King. If there's anything I can do to assist with this pull request, please don't hesitate to ask. Thank you!

Best regards,
-King

#### Description
This pull request resolves an issue where a white bar appeared at the bottom of the screen in the `Managed View` app on iOS 11 and later, caused by `WKWebView`’s default content inset adjustment for safe areas. By setting `contentInsetAdjustmentBehavior` to `.never`, the web content now fills the entire view. Additionally, this change refactors the `WKWebView` setup into a shared `configureWebView` method to reduce duplication and improve maintainability.

#### Changes
- **Introduced `configureWebView` Method**: Consolidated `WKWebView` initialization logic into a reusable function:
  ```swift
  private func configureWebView(isPrivate: Bool = false) -> WKWebView {
      let webConfiguration = WKWebViewConfiguration()
      if isPrivate {
          webConfiguration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
      }
      let webView = WKWebView(frame: .zero, configuration: webConfiguration)
      webView.uiDelegate = self
      webView.navigationDelegate = self
      browserURL.delegate = self
      if #available(iOS 11.0, *) {
          webView.scrollView.contentInsetAdjustmentBehavior = .never
      }
      return webView
  }
  ```
- **Updated Existing Methods**:
  - Replaced `newWebView()` with:
    ```swift
    func newWebView() {
        webView = configureWebView()
        view = webView
        NSLog("Initiate webview - persistant")
    }
    ```
  - Replaced `newWebViewPrivate()` with:
    ```swift
    func newWebViewPrivate() {
        webView = configureWebView(isPrivate: true)
        view = webView
        NSLog("Initiate webview - non-persistant")
    }
    ```
- **Fixes White Bar**: The `contentInsetAdjustmentBehavior = .never` setting ensures no extra padding is added at the bottom of the screen on iOS 11+.

#### Impact
- **Visual Fix**: Eliminates the white bar, making web content edge-to-edge.
- **Code Quality**: Reduces duplication between persistent and private web view setup, centralizing configuration logic.
- **Compatibility**: Uses `#available` to maintain default behavior on iOS < 11.0.
- **No Functional Impact**: Only affects layout and code structure; core app features (e.g., Managed App Config, ASAM) remain unchanged.

#### Testing
- Tested on iOS 16 simulator and iPhone 14 with `MAINTENANCE_MODE=OFF`, `BROWSER_MODE=ON/OFF`, and `PRIVATE_BROWSING=ON/OFF`.
- Verified no white bar in both persistent and private browsing modes.
- Confirmed web content loads correctly and navigation works as expected.

#### Steps to Verify
1. Build and run on an iOS 11+ device or simulator.
2. Load a URL (e.g., default or custom via Managed App Config).
3. Ensure web content fills the screen with no white bar at the bottom.
4. Switch between persistent and private modes to confirm consistency.


#### Notes
- The refactored approach keeps the fix applied synchronously during web view creation, avoiding timing issues with `DispatchQueue.main.async`.
- This structure makes future `WKWebView` configuration changes easier to manage in one place.

#### Screenshots 
| Before | After |
| --- | --- |
| <img width="1426" alt="Screenshot 2025-03-10 at 4 17 12 PM" src="https://github.com/user-attachments/assets/8393e00a-3323-4b53-8758-97c9b69a426f" /> | <img width="1426" alt="Screenshot 2025-03-10 at 4 15 59 PM" src="https://github.com/user-attachments/assets/c3ade9ce-a280-4453-bec7-466abf26cc50" /> |
